### PR TITLE
Find dotnet from return processes

### DIFF
--- a/src/StalkerDebugAdapter.ts
+++ b/src/StalkerDebugAdapter.ts
@@ -167,7 +167,7 @@ export class StalkerDebugAdapter implements Disposable, DebugAdapter {
         this.checkProcessesTimeout = setTimeout(async () => {
             const dotNetWatchProcessNameRegExp = new RegExp(`dotnet.* watch run .*--project "?${this.debugConfiguration.project.replaceAll("\\", "\\\\")}"?`, "i");
             const dotNetWatchProcesses = await findProcesses("name", dotNetWatchProcessNameRegExp);
-            const dotNetWatchProcess = dotNetWatchProcesses.length === 1 ? dotNetWatchProcesses[0] : undefined;
+            const dotNetWatchProcess = dotNetWatchProcesses.find(x => x.name.toLowerCase().startsWith("dotnet"));
 
             // if (dotNetWatchProcess) console.log(`dotnet watch command: ${dotNetWatchProcess.cmd}`);
             // else console.log("dotnet watch process not found");


### PR DESCRIPTION
Fix: #2 

On Windows, dotnet watch spawns two processes: dotnet.exe and pwsh.exe.

This caused the existing code to return undefined.

<img width="938" height="388" alt="image" src="https://github.com/user-attachments/assets/82a8912f-d918-49e5-989f-ce43e069e006" />